### PR TITLE
Add lib SchemaPath for inventory path query on JSON object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __inventory
 .idea/*
 *.db
+__debug_bin

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Inventory Service With Docker",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/app/InventoryService/main.go",
+            "args": ["-config", "${workspaceFolder}/docker-compose/2data1inv/InventoryService/extConfig/config.json"],
+        }
+    ]
+}

--- a/docker-compose/2data1inv/InventoryService/data/inventory/DataService_01
+++ b/docker-compose/2data1inv/InventoryService/data/inventory/DataService_01
@@ -1,6 +1,11 @@
 {
  "__id": "DataService_01",
  "lastSynctime": "",
- "typeList": [],
- "url": "http://unitao-data-service01"
+ "typeList": [
+  "NETSEC-SOT-EIP"
+ ],
+ "url": [
+    "http://unitao-data-service01",
+    "http://localhost:8002"
+]
 }

--- a/docker-compose/2data1inv/InventoryService/data/inventory/DataService_02
+++ b/docker-compose/2data1inv/InventoryService/data/inventory/DataService_02
@@ -1,6 +1,13 @@
 {
  "__id": "DataService_02",
  "lastSynctime": "",
- "typeList": [],
- "url": "http://unitao-data-service02"
+ "typeList": [
+  "FalconDomainInstance",
+  "FalconInstance",
+  "FalconService"
+ ],
+ "url": [
+    "http://unitao-data-service02",
+    "http://localhost:8003"
+ ]
 }

--- a/docker-compose/2data1inv/InventoryService/extConfig/config.json
+++ b/docker-compose/2data1inv/InventoryService/extConfig/config.json
@@ -1,0 +1,14 @@
+{
+    "database": {
+        "type": "sysdirfile",
+        "sysdirfile": {
+            "path": "../../docker-compose/2data1inv/InventoryService/data"
+        }
+    },
+    "http": {
+        "type": "http",
+        "dns": "localhost",
+        "port": "8005",
+        "id": "Inventory"
+    }
+}

--- a/lib/Schema/schema.go
+++ b/lib/Schema/schema.go
@@ -75,7 +75,7 @@ func (schema *SchemaOps) init() error {
 	if err != nil {
 		return fmt.Errorf("copy schema.Record.Data failed. Error: %s", err)
 	}
-	doc, err := SchemaDoc.NewSchemaDoc(schemaData.(map[string]interface{}), schema.Record.Id, nil)
+	doc, err := SchemaDoc.New(schemaData.(map[string]interface{}), schema.Record.Id, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create Schema Doc, err: %s", err)
 	}

--- a/lib/SchemaPath/connection.go
+++ b/lib/SchemaPath/connection.go
@@ -23,25 +23,18 @@ This copyright notice and license applies to all files in this directory or sub-
 ************************************************************************************************************
 */
 
-package JsonKey
+package SchemaPath
 
-const (
-	AdditionalProperties = "additionalProperties"
-	Array                = "array"
-	ContentMediaType     = "contentMediaType"
-	Definitions          = "definitions"
-	DefinitionPrefix     = "#/definitions/"
-	DocRoot              = "*"
-	Items                = "items"
-	Inventory            = "inventory"
-	Key                  = "key"
-	Name                 = "name"
-	Map                  = "map"
-	Object               = "object"
-	Properties           = "properties"
-	Ref                  = "$ref"
-	Required             = "required"
-	Schema               = "schema"
-	String               = "string"
-	Type                 = "type"
+import (
+	"github.com/salesforce/UniTAO/lib/Schema/Record"
+	"github.com/salesforce/UniTAO/lib/Schema/SchemaDoc"
 )
+
+type FuncSchema func(dataType string) (*SchemaDoc.SchemaDoc, error)
+
+type FuncRecord func(dataType string, dataId string) (*Record.Record, error)
+
+type Connection struct {
+	GetSchema FuncSchema
+	GetRecord FuncRecord
+}

--- a/lib/SchemaPath/go.mod
+++ b/lib/SchemaPath/go.mod
@@ -21,18 +21,8 @@
 // This copyright notice and license applies to all files in this directory or sub-directories, except when stated otherwise explicitly.
 // ******************************************************************************************************************
 
+module github.com/salesforce/UniTAO/lib/SchemaPath
+
 go 1.18
 
-use (
-    ./app/DataService
-    ./app/InventoryService
-    ./lib/Schema
-    ./lib/SchemaPath
-    ./lib/Util
-    ./src/Data
-    ./src/DataService
-    ./src/InventoryService
-    ./tool/DataServiceAdmin
-    ./tool/InventoryServiceAdmin
-    ./test/src
-)
+

--- a/lib/SchemaPath/schemaPath.go
+++ b/lib/SchemaPath/schemaPath.go
@@ -1,0 +1,271 @@
+/*
+************************************************************************************************************
+Copyright (c) 2022 Salesforce, Inc.
+All rights reserved.
+
+UniTAO was originally created in 2022 by Shai Herzog & Yi Huo as an
+Universal No-Coding Heterogeneous Infrastructure Maintenance & Inventory system that is holistically driven by open/community-developed semantic models/schemas.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+This copyright notice and license applies to all files in this directory or sub-directories, except when stated otherwise explicitly.
+************************************************************************************************************
+*/
+
+package SchemaPath
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/salesforce/UniTAO/lib/Schema/JsonKey"
+	"github.com/salesforce/UniTAO/lib/Schema/SchemaDoc"
+	"github.com/salesforce/UniTAO/lib/Util"
+)
+
+type SchemaPath struct {
+	conn     *Connection
+	schema   *SchemaDoc.SchemaDoc
+	fullPath string
+	nextPath string
+	prev     *SchemaPath
+	data     map[string]interface{}
+}
+
+func New(conn *Connection, schema *SchemaDoc.SchemaDoc, fullPath string, nextPath string, prev *SchemaPath, data map[string]interface{}) *SchemaPath {
+	schemaPath := SchemaPath{
+		conn:     conn,
+		schema:   schema,
+		fullPath: fullPath,
+		nextPath: nextPath,
+		prev:     prev,
+		data:     data,
+	}
+	return &schemaPath
+}
+
+func NewFromPath(conn *Connection, path string, prev *SchemaPath) (*SchemaPath, error) {
+	fullPath := ""
+	if prev != nil {
+		fullPath = prev.fullPath
+	}
+	dataType, nextPath := Util.ParsePath(path)
+	if nextPath == "" {
+		return nil, fmt.Errorf("missing id from path=[%s/%s]", fullPath, dataType)
+	}
+	schema, err := conn.GetSchema(dataType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get schema [type]=[%s] @[path]=[%s]", dataType, fullPath)
+	}
+	fullPath = fmt.Sprintf("%s/%s", fullPath, dataType)
+
+	dataId, nextPath := Util.ParsePath(nextPath)
+	record, err := conn.GetRecord(dataType, dataId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get record [type/id]=[%s/%s] @[path]=[%s]", dataType, dataId, fullPath)
+	}
+	fullPath = fmt.Sprintf("%s/%s", fullPath, dataId)
+
+	return New(conn, schema, fullPath, nextPath, prev, record.Data), nil
+}
+
+func ParseArrayPath(path string) (string, string) {
+	if path[len(path)-1:] != "]" {
+		return path, ""
+	}
+	keyIdx := strings.Index(path, "[")
+	if keyIdx < 1 {
+		return path, ""
+	}
+	attrName := path[:keyIdx]
+	key := path[keyIdx+1 : len(path)-1]
+	return attrName, key
+}
+
+func (p *SchemaPath) WalkValue() (interface{}, error) {
+	// no more path to walk. return current value
+	if p.nextPath == "" {
+		return p.data, nil
+	}
+	attrPath, nextPath := Util.ParsePath(p.nextPath)
+	attrName, attrIdx := ParseArrayPath(attrPath)
+	attrDef, ok := p.schema.Data[JsonKey.Properties].(map[string]interface{})[attrName].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("attr=[%s] is not a defined attribute. @[path]=[%s/%s]", attrName, p.fullPath, attrPath)
+	}
+	attrValue, ok := p.data[attrName]
+	if !ok || attrValue == nil {
+		log.Printf("data does not exists or is nil. @[path]=[%s/%s]", p.fullPath, attrName)
+		return nil, nil
+	}
+	attrType := attrDef[JsonKey.Type].(string)
+	if attrIdx != "" && attrType != JsonKey.Array {
+		return nil, fmt.Errorf("only [%s] support idx path, attr [%s] type=[%s], @[path]=[%s]", JsonKey.Array, attrName, attrType, p.fullPath)
+	}
+	switch attrType {
+	case JsonKey.Array:
+		log.Printf("walk into array")
+		return p.WalkArray(attrName, attrIdx, attrDef[JsonKey.Items].(map[string]interface{}), attrValue, nextPath)
+	case JsonKey.Object:
+		log.Printf("walk into object @[path]=[%s/%s]", p.fullPath, attrName)
+		if SchemaDoc.IsMap(attrDef) {
+			return p.WalkMap(attrName, attrDef[JsonKey.AdditionalProperties].(map[string]interface{}), attrValue, nextPath)
+		}
+		return p.WalkObject(attrName, attrValue, nextPath)
+	case JsonKey.String:
+		log.Printf("walk into CMT ref")
+		attrValue, err := p.WalkCMTIdx(attrName, attrValue.(string), nextPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get CMDIdx. [%s]=[%s], @[path]=[%s]", attrName, attrValue, p.fullPath)
+		}
+		return attrValue, nil
+	default:
+		if nextPath != "" {
+			return nil, fmt.Errorf("[type]=[%s] does not support ref work, @[path]=[%s/%s]", attrType, p.fullPath, attrName)
+		}
+		return attrValue, nil
+	}
+}
+
+func (p *SchemaPath) WalkArray(attrName string, attrIdx string, attrDef map[string]interface{}, attrValue interface{}, nextPath string) (interface{}, error) {
+	itemType := attrDef[JsonKey.Type].(string)
+	valueList := []interface{}{}
+	switch itemType {
+	case JsonKey.Object:
+		itemDoc, ok := p.schema.SubDocs[attrName]
+		if !ok {
+			if nextPath == "" && attrIdx == "" {
+				return attrValue, nil
+			}
+			return nil, fmt.Errorf("failed to load item object schema. @[path]=[%s/%s]", p.fullPath, attrName)
+		}
+		if attrIdx != "" && itemDoc.KeyTemplate == "" {
+			return nil, fmt.Errorf(`
+				attr=[%s], type=[%s] has no template definition [%s] in schema, 
+				index no key object not supported. @[path]=[%s/%s[%s]]`,
+				attrName, itemDoc.Id, JsonKey.Key,
+				p.fullPath, attrName, attrIdx)
+		}
+		for _, item := range attrValue.([]interface{}) {
+			itemKey := itemDoc.BuildKey(item.(map[string]interface{}))
+			if attrIdx != "" && attrIdx != itemKey {
+				continue
+			}
+			itemValue, err := p.WalkObject(attrName, item, nextPath)
+			if err != nil {
+				return nil, err
+			}
+			if itemKey == attrIdx {
+				return itemValue, nil
+			}
+			valueList = append(valueList, itemValue)
+		}
+		return valueList, nil
+	case JsonKey.String:
+		for _, item := range attrValue.([]interface{}) {
+			key := item.(string)
+			if attrIdx != "" && attrIdx != key {
+				continue
+			}
+			cmtValue, err := p.WalkCMTIdx(attrName, key, nextPath)
+			if err != nil {
+				return nil, err
+			}
+			if key == attrIdx {
+				return cmtValue, nil
+			}
+			valueList = append(valueList, cmtValue)
+		}
+		return valueList, nil
+	default:
+		if attrIdx != "" {
+			return nil, fmt.Errorf("type []%s does not support idx, @[path]=[%s/%s]", itemType, p.fullPath, attrName)
+		}
+		if nextPath != "" {
+			return nil, fmt.Errorf("type []%s does not support walk in, @[path]=[%s/%s]", itemType, p.fullPath, attrName)
+		}
+		return attrValue, nil
+	}
+}
+
+func (p *SchemaPath) WalkCMTIdx(attrName string, attrValue string, nextPath string) (interface{}, error) {
+	cmtRef, ok := p.schema.CmtRefs[attrName]
+	if !ok {
+		log.Printf("[attr]=[%s] has no Cmt Ref @[path]=[%s]", attrName, p.fullPath)
+		return attrValue, nil
+	}
+	if nextPath == "" {
+		// if no further path to walk
+		return attrValue, nil
+	}
+	cmtPath := fmt.Sprintf("%s/%s", cmtRef.ContentType, attrValue)
+	if nextPath != JsonKey.DocRoot {
+		cmtPath = fmt.Sprintf("%s/%s", cmtPath, nextPath)
+	}
+	cmt, err := NewFromPath(p.conn, cmtPath, p)
+	if err != nil {
+		return nil, err
+	}
+	cmtValue, err := cmt.WalkValue()
+	if err != nil {
+		return nil, err
+	}
+	return cmtValue, nil
+}
+
+func (p *SchemaPath) WalkMap(attrName string, mapDef map[string]interface{}, attrValue interface{}, nextPath string) (interface{}, error) {
+	if nextPath == "" {
+		return attrValue, nil
+	}
+	itemKey, nextPath := Util.ParsePath(nextPath)
+	itemValue, ok := attrValue.(map[string]interface{})[itemKey]
+	if !ok {
+		log.Printf("map [itemKey]=[%s] does not exists. @[path]=[%s/%s]", itemKey, p.fullPath, attrName)
+		return nil, nil
+	}
+	switch mapDef[JsonKey.Type].(string) {
+	case JsonKey.String:
+		cmtValue, err := p.WalkCMTIdx(attrName, itemValue.(string), nextPath)
+		if err != nil {
+			return nil, err
+		}
+		return cmtValue, nil
+	case JsonKey.Object:
+		objValue, err := p.WalkObject(attrName, itemValue.(map[string]interface{}), nextPath)
+		if err != nil {
+			return nil, err
+		}
+		return objValue, nil
+	}
+	return itemValue, nil
+}
+
+func (p *SchemaPath) WalkObject(attrName string, attrValue interface{}, nextPath string) (interface{}, error) {
+	if nextPath == "" {
+		return attrValue, nil
+	}
+	itemDoc, ok := p.schema.SubDocs[attrName]
+	if !ok {
+		return nil, fmt.Errorf("failed to get schema for @[path]=[%s/%s]", p.fullPath, attrName)
+	}
+	fullPath := fmt.Sprintf("%s/%s", p.fullPath, attrName)
+	data := attrValue.(map[string]interface{})
+	objPath := New(p.conn, itemDoc, fullPath, nextPath, p, data)
+	objValue, err := objPath.WalkValue()
+	if err != nil {
+		return nil, err
+	}
+	return objValue, nil
+}

--- a/lib/Util/util.go
+++ b/lib/Util/util.go
@@ -37,6 +37,7 @@ import (
 	"path"
 	"reflect"
 	"strings"
+	"time"
 )
 
 type HttpConfig struct {
@@ -153,6 +154,19 @@ func PostRestData(dataUrl string, payload interface{}) (int, error) {
 		return resp.StatusCode, fmt.Errorf("failed to post data to [url]=[%s], Error:%s", dataUrl, err)
 	}
 	return http.StatusAccepted, nil
+}
+
+func SiteReachable(url string) bool {
+	timeout := 1 * time.Second
+	client := http.Client{
+		Timeout: timeout,
+	}
+	_, err := client.Get(url)
+	if err != nil {
+		log.Println("Site unreachable, error: ", err)
+		return false
+	}
+	return true
 }
 
 func SearchStrList(searchAry []string, value string) bool {

--- a/src/DataService/DataHandler/dataHandler.go
+++ b/src/DataService/DataHandler/dataHandler.go
@@ -235,7 +235,7 @@ func (h *Handler) validateCmtRefs(doc *SchemaDoc.SchemaDoc, data map[string]inte
 	return http.StatusAccepted, nil
 }
 
-func (h *Handler) validateCmtRefValue(ref *SchemaDoc.SchemaDocRef, value string) (bool, error) {
+func (h *Handler) validateCmtRefValue(ref *SchemaDoc.CMTDocRef, value string) (bool, error) {
 	typePath, dataType := Util.ParsePath(ref.ContentType)
 	if typePath != Schema.Inventory {
 		// ContentMediaType not start with inventory, we don't understand

--- a/src/InventoryService/InventoryServer/inventoryServer.go
+++ b/src/InventoryService/InventoryServer/inventoryServer.go
@@ -109,14 +109,14 @@ func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Inventory Server only support GET method", http.StatusMethodNotAllowed)
 		return
 	}
-	dataType, dataId := Util.ParsePath(r.URL.Path)
+	dataType, dataPath := Util.ParsePath(r.URL.Path)
 	if dataType == "" {
 		respObj := make(map[string]string)
 		respObj["error message"] = "please use inventory{type}[/{id}]"
 		Util.ResponseJson(w, respObj, http.StatusOK)
 		return
 	}
-	if dataId == "" {
+	if dataPath == "" {
 		idList, code, err := srv.data.List(dataType)
 		if err != nil {
 			http.Error(w, err.Error(), code)
@@ -125,7 +125,7 @@ func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
 		Util.ResponseJson(w, idList, code)
 		return
 	}
-	data, code, err := srv.data.Get(dataType, dataId)
+	data, code, err := srv.data.Get(dataType, dataPath)
 	if err != nil {
 		http.Error(w, err.Error(), code)
 		return

--- a/test/src/SchemaPathTest/schemaPath_test.go
+++ b/test/src/SchemaPathTest/schemaPath_test.go
@@ -1,0 +1,478 @@
+/*
+************************************************************************************************************
+Copyright (c) 2022 Salesforce, Inc.
+All rights reserved.
+
+UniTAO was originally created in 2022 by Shai Herzog & Yi Huo as an
+Universal No-Coding Heterogeneous Infrastructure Maintenance & Inventory system that is holistically driven by open/community-developed semantic models/schemas.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+This copyright notice and license applies to all files in this directory or sub-directories, except when stated otherwise explicitly.
+************************************************************************************************************
+*/
+
+package SchemaPathTest
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/salesforce/UniTAO/lib/Schema/Record"
+	"github.com/salesforce/UniTAO/lib/Schema/SchemaDoc"
+	"github.com/salesforce/UniTAO/lib/SchemaPath"
+)
+
+func PrepareConn(schemaStr string, recordStr string) *SchemaPath.Connection {
+	getSchema := func(dataType string) (*SchemaDoc.SchemaDoc, error) {
+		schemaMap := map[string]interface{}{}
+		err := json.Unmarshal([]byte(schemaStr), &schemaMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to ummarshal schema map str, Error:%s", err)
+		}
+		schemaData, ok := schemaMap[dataType].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("schema [type]=[%s] does not exists", dataType)
+		}
+		return SchemaDoc.New(schemaData, dataType, nil)
+	}
+	getRecord := func(dataType string, dataId string) (*Record.Record, error) {
+		recordMap := map[string]interface{}{}
+		err := json.Unmarshal([]byte(recordStr), &recordMap)
+		if err != nil {
+			return nil, fmt.Errorf("failed to ummarshal schema map str, Error:%s", err)
+		}
+		data, ok := recordMap[dataType].(map[string]interface{})[dataId].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("record [%s/%s] does not exists", dataType, dataId)
+		}
+		record, err := Record.LoadMap(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load data as Record. Error:%s", err)
+		}
+		return record, nil
+	}
+	conn := SchemaPath.Connection{
+		GetSchema: getSchema,
+		GetRecord: getRecord,
+	}
+	return &conn
+
+}
+
+func TestConn(t *testing.T) {
+	schemaStr := `
+		{
+			"testSch01": {
+				"name": "testSch01",
+				"description": "Test Schema 01",
+				"properties": {
+					"testAttr01": {
+						"type": "string"
+					}
+				}
+			}
+		}
+	`
+	recordStr := `
+		{
+			"testSch01": {
+				"testId01": {
+					"__id": "testId01",
+					"__type": "testSch01",
+					"__ver": "0.0.1",
+					"data": {
+						"testAttr01": "testValue01"
+					}
+				}
+			}
+		}
+	`
+	conn := PrepareConn(schemaStr, recordStr)
+	schema, err := conn.GetSchema("testSch01")
+	if err != nil {
+		t.Errorf("failed while get schema=[testSch01], Error:%s", err)
+	}
+	if schema.Id != "testSch01" {
+		t.Errorf("failed to get schema=[testSch01], got [" + schema.Id + "] instead")
+	}
+	record, err := conn.GetRecord("testSch01", "testId01")
+	if err != nil {
+		t.Errorf("failed to get record [type/id]=[testSch01/testId01], Error: %s", err)
+	}
+	if record.Id != "testId01" {
+		t.Errorf("got wrong record.id [%s]!=[testId01]", record.Id)
+	}
+}
+
+func TestWalkInObjectAndMap(t *testing.T) {
+	schemaStr := `
+	{
+		"schema1": {
+			"name": "schema1",
+			"description": "test schema 01",
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"value": {
+					"type": "object",
+					"$ref": "#/definitions/testValue"
+				},
+				"mapStr": {
+					"type": "map",
+					"items": {
+						"type": "string"
+					}
+				}
+			},
+			"definitions": {
+				"testValue": {
+					"properties": {
+						"value1": {
+							"type": "string"
+						},
+						"value2": {
+							"type": "string"
+						}
+					}
+				}
+			}
+
+		}
+	}`
+	recordStr := `{
+		"schema1": {
+			"data1": {
+				"__id": "data1",
+				"__type": "schema1",
+				"__ver": "0.0.1",
+				"data": {
+					"name": "data1",
+					"value": {
+						"value1": "01",
+						"value2": "02"
+					},
+					"mapStr": {
+						"keyExists": "exists"
+					}
+				}
+			}
+		}
+	}`
+	conn := PrepareConn(schemaStr, recordStr)
+	queryPath := "schema1/data1/value/value1"
+	schemaPath, err := SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	value1, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if value1.(string) != "01" {
+		t.Errorf("invalid value from [path]=[%s], [%s]!=[01]", queryPath, value1.(string))
+	}
+	queryPath = "schema1/data1/mapStr/keyExists"
+	schemaPath, err = SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	valueExists, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if valueExists.(string) != "exists" {
+		t.Errorf("invalid value from [path]=[%s], [%s]!=[exists]", queryPath, valueExists.(string))
+	}
+	queryPath = "schema1/data1/mapStr/keyNotExists"
+	schemaPath, err = SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	valueNotExists, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if valueNotExists != nil {
+		t.Errorf("invalid value from [path]=[%s], [%s]!=[nil]", queryPath, valueNotExists.(string))
+	}
+}
+
+func TestWalkInArray(t *testing.T) {
+	schemaStr := `
+		{
+			"schemaWitArray": {
+				"name": "schemaWitArray",
+				"description": "schema of object with array of object in attribute",
+				"properties": {
+					"attrArray": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"$ref": "#/definitions/itemObj"
+						}
+					}
+				},
+				"definitions": {
+					"itemObj": {
+						"description": "item object of an array",
+						"key": "{key1}_{key2}",
+						"properties": {
+							"key1": {
+								"type": "string"
+							},
+							"key2": {
+								"type": "string"
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+	recordStr := `
+	{
+		"schemaWitArray": {
+			"testArray01": {
+				"__id": "testArray01",
+				"__type": "schemaWitArray",
+				"__ver": "0.0.1",
+				"data": {
+					"attrArray": [
+						{
+							"key1": "01",
+							"key2": "01"
+						},
+						{
+							"key1": "01",
+							"key2": "02"
+						}
+					]
+				}
+			}
+		}
+	}`
+	conn := PrepareConn(schemaStr, recordStr)
+	queryPath := "schemaWitArray/testArray01/attrArray"
+	schemaPath, err := SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	arrayValue, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if reflect.TypeOf(arrayValue).Kind() != reflect.Slice {
+		t.Errorf("failed to get array from path=[%s]", queryPath)
+	}
+	queryPath = "schemaWitArray/testArray01/attrArray[01_01]"
+	schemaPath, err = SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	itemValue, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if itemValue == nil {
+		t.Errorf("failed to get the value of idx=[01_01], @[path]=[%s]", queryPath)
+	}
+	if itemValue.(map[string]interface{})["key2"] != "01" {
+		t.Errorf("failed to get the correct value from [path]=[%s]", queryPath)
+	}
+	queryPath = "schemaWitArray/testArray01/attrArray[01_02]/key2"
+	schemaPath, err = SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	keyValue, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if keyValue == nil {
+		t.Errorf("failed to get the value of idx=[01_01], @[path]=[%s]", queryPath)
+	}
+	if keyValue.(string) != "02" {
+		t.Errorf("failed to get the correct value=[%s] from [path]=[%s]", keyValue.(string), queryPath)
+	}
+}
+
+func TestWalkInRef(t *testing.T) {
+	schemaStr := `
+		{
+			"schemaWithRef": {
+				"name": "schemaWitArray",
+				"description": "schema of object with array of object in attribute",
+				"properties": {
+					"itemArray": {
+						"type": "array",
+						"items": {
+							"type": "object",
+							"$ref": "#/definitions/itemObj"
+						}
+					}
+				},
+				"definitions": {
+					"itemObj": {
+						"description": "item object of an array",
+						"key": "{key1}_{key2}",
+						"properties": {
+							"key1": {
+								"type": "string"
+							},
+							"key2": {
+								"type": "string"
+							},
+							"refIdx": {
+								"type": "string",
+								"contentMediaType": "inventory/schemaRef"
+							}
+						}
+					}
+				}
+			},
+			"schemaRef": {
+				"name": "schemaRef",
+				"description": "schema of ref object",
+				"properties": {
+					"data": {
+						"type": "object",
+						"$ref": "#/definitions/data"
+					}
+				},
+				"definitions": {
+					"data": {
+						"description": "data wrapper for the keyed map",
+						"properties": {
+							"name": {
+								"type": "string"
+							},
+							"items": {
+								"type": "map",
+								"items": {
+									"type": "object",
+									"$ref": "#/definitions/itemData"
+								}
+							}
+						}
+					},
+					"itemData": {
+						"description": "mapped item data schema",
+						"properties": {
+							"attr01": {
+								"type": "string"
+							},
+							"attr02": {
+								"type": "string"
+							}
+						}
+					}
+				}
+			}
+		}
+	`
+	recordStr := `
+	{
+		"schemaWithRef": {
+			"refData01": {
+				"__id": "refData01",
+				"__type": "schemaWithRef",
+				"__ver": "0.0.1",
+				"data": {
+					"itemArray": [
+						{
+							"key1": "01",
+							"key2": "01",
+							"refIdx": "ref01/data/items/item01/attr01"
+						},
+						{
+							"key1": "01",
+							"key2": "02",
+							"refIdx": "ref02/data/items/item02/attr02"
+						}
+					]
+				}
+			}
+		},
+		"schemaRef": {
+			"ref01": {
+				"__id": "ref01",
+				"__type": "schemaRef",
+				"__ver": "0.0.1",
+				"data" : {
+					"data": {
+						"name": "ref01",
+						"items": {
+							"item01": {
+								"attr01": "value01-01-01",
+								"attr02": "value01-01-02"
+							}
+						}
+					}
+				}
+			},
+			"ref02": {
+				"__id": "ref02",
+				"__type": "schemaRef",
+				"__ver": "0.0.1",
+				"data" : {
+					"data": {
+						"name": "ref02",
+						"items": {
+							"item02": {
+								"attr01": "value02-02-01",
+								"attr02": "value02-02-02"
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+	conn := PrepareConn(schemaStr, recordStr)
+	queryPath := "schemaWithRef/refData01/itemArray[01_01]/refIdx"
+	schemaPath, err := SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	refPath, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if refPath == nil {
+		t.Errorf("failed to get the value of idx=[01_01], @[path]=[%s]", queryPath)
+	}
+	if refPath.(string) != "ref01/data/items/item01/attr01" {
+		t.Errorf("failed to get the correct value=[%s] from [path]=[%s]", refPath.(string), queryPath)
+	}
+	queryPath = "schemaWithRef/refData01/itemArray[01_01]/refIdx/*"
+	schemaPath, err = SchemaPath.NewFromPath(conn, queryPath, nil)
+	if err != nil {
+		t.Errorf("failed to generate SchemaPath. from [path]=[%s], Error: %s", queryPath, err)
+	}
+	refValue, err := schemaPath.WalkValue()
+	if err != nil {
+		t.Errorf("failed to parse value from [path]=[%s], Error: %s", queryPath, err)
+	}
+	if refValue == nil {
+		t.Errorf("failed to get the value of idx=[01_01], @[path]=[%s]", queryPath)
+	}
+	if refValue.(string) != "value01-01-01" {
+		t.Errorf("failed to get the correct value. [%s]!=[value01-01-01]", refValue.(string))
+	}
+
+}

--- a/test/src/SchemaTest/schemaDoc_test.go
+++ b/test/src/SchemaTest/schemaDoc_test.go
@@ -1,0 +1,109 @@
+/*
+************************************************************************************************************
+Copyright (c) 2022 Salesforce, Inc.
+All rights reserved.
+
+UniTAO was originally created in 2022 by Shai Herzog & Yi Huo as an
+Universal No-Coding Heterogeneous Infrastructure Maintenance & Inventory system that is holistically driven by open/community-developed semantic models/schemas.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+This copyright notice and license applies to all files in this directory or sub-directories, except when stated otherwise explicitly.
+************************************************************************************************************
+*/
+
+package SchemaTest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/salesforce/UniTAO/lib/Schema/Record"
+	"github.com/salesforce/UniTAO/lib/Schema/SchemaDoc"
+)
+
+func TestOjectKeyAttrRequired(t *testing.T) {
+	schemaStr := `{
+		"name": "test",
+		"description": "test schema",
+		"key": "{type}_{name}_{version}",
+		"properties": {
+			"name": {
+				"type": "string"
+			},
+			"type": {
+				"type": "string"
+			},
+			"version": {
+				"type": "string",
+				"required": false
+			}
+		}
+	}`
+	data := map[string]interface{}{}
+	err := json.Unmarshal([]byte(schemaStr), &data)
+	if err != nil {
+		t.Errorf("failed to load schemaStr. Error:%s", err)
+	}
+	_, err = SchemaDoc.New(data, "test", nil)
+	if err == nil {
+		t.Errorf("failed to validate key [attr]=[version]] as required")
+	}
+}
+
+func TestObjectKey(t *testing.T) {
+	schemaStr := `{
+		"name": "test",
+		"description": "test schema",
+		"key": "{type}_{name}_{version}",
+		"properties": {
+			"name": {
+				"type": "string"
+			},
+			"type": {
+				"type": "string"
+			},
+			"version": {
+				"type": "string"
+			}
+		}
+	}`
+	recordStr := `{
+		"__id": "test_key_01",
+		"__type": "test",
+		"__ver": "0.0.1",
+		"data": {
+			"name": "key",
+			"type": "test",
+			"version": "01"
+		}
+	}`
+	data := map[string]interface{}{}
+	err := json.Unmarshal([]byte(schemaStr), &data)
+	if err != nil {
+		t.Errorf("failed to load schemaStr. Error:%s", err)
+	}
+	schema, err := SchemaDoc.New(data, "test", nil)
+	if err != nil {
+		t.Errorf("failed to load schemaStr as SchemaDoc")
+	}
+	record, err := Record.LoadStr(recordStr)
+	if err != nil {
+		t.Errorf("failed to load recordStr as Record")
+	}
+	recordKey := schema.BuildKey(record.Data)
+	if recordKey != record.Id {
+		t.Errorf("build the wrong key. [%s]!=[%s]", recordKey, record.Id)
+	}
+}

--- a/tool/InventoryServiceAdmin/main.go
+++ b/tool/InventoryServiceAdmin/main.go
@@ -204,7 +204,11 @@ func (a *Admin) syncSchemaWithId(dsId string) error {
 	if err != nil {
 		return fmt.Errorf("format error, failed to parse DS record [%s]=[%s] to DataServiceInfo, Error:%s", Record.DataId, a.args.ops.id, err)
 	}
-	schemaUrl, err := Util.URLPathJoin(ds.URL, JsonKey.Schema)
+	dsUrl, err := ds.GetUrl()
+	if err != nil {
+		return err
+	}
+	schemaUrl, err := Util.URLPathJoin(dsUrl, JsonKey.Schema)
 	if err != nil {
 		return fmt.Errorf("failed to parse url from DS record [%s]=[%s], Err:%s", Record.DataId, a.args.ops.id, err)
 	}


### PR DESCRIPTION
- add lib SchemaPath for JSON object path walk
- fix SchemaDoc library for better naming
- change Inventory Record format. URL become a list instead of string to allow alias on DataService Address
- add extConfig setup in docker-compose to help InventoryService and DataService outside of Docker network
- add Util function. SiteReachable to test url
- InventoryService to allow Path instead of id after data type