### PR TITLE
Feature data service walk on path

### DIFF
--- a/demo/demo01/data/dsMap.json
+++ b/demo/demo01/data/dsMap.json
@@ -1,0 +1,8 @@
+{
+    "DataService_01": {
+        "url": "http://localhost:8001"
+    },
+    "DataService_02": {
+        "url": "http://localhost:8002"
+    }
+}

--- a/lib/Schema/JsonKey/jsonKey.go
+++ b/lib/Schema/JsonKey/jsonKey.go
@@ -56,10 +56,12 @@ var InvalidTypeChars = []string{
 	"$",
 	"[",
 	"]",
+	"?",
 }
 
 var InvalidKeyChars = []string{
 	"/",
 	"[",
 	"]",
+	"?",
 }

--- a/src/DataService/DataJournal/Process/cmtIndex.go
+++ b/src/DataService/DataJournal/Process/cmtIndex.go
@@ -90,7 +90,7 @@ func (s *CmtIndexChanges) HandleType(dataType string, version string) (bool, err
 
 func (s *CmtIndexChanges) isSubscribedType(dataType string) (bool, *Http.HttpError) {
 	s.Log(fmt.Sprintf("check if data of [%s] is subscribed", dataType))
-	_, err := s.Data.Get(CmtIndex.KeyCmtIdx, dataType)
+	_, err := s.Data.LocalData(CmtIndex.KeyCmtIdx, dataType)
 	if err != nil {
 		if err.Status == http.StatusNotFound {
 			return false, nil
@@ -140,7 +140,7 @@ func (s *CmtIndexChanges) processSubscribedDataChange(dataType string, dataId st
 	if entry.Before == nil && entry.After == nil {
 		return Http.NewHttpError(fmt.Sprintf("[%s/%s] entry page/idx=[%d/%d], have both Before and After empty.", dataType, dataId, entry.Page, entry.Idx), http.StatusNotModified)
 	}
-	cmtIdxData, err := s.Data.GetData(CmtIndex.KeyCmtIdx, dataType)
+	cmtIdxData, err := s.Data.LocalData(CmtIndex.KeyCmtIdx, dataType)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (s *CmtIndexChanges) processSubscribedDataChange(dataType string, dataId st
 		if ex != nil {
 			s.log.Printf("failed to load entry.After as record. [%s/%s], page/idx=[%d/%d], Error:%s", dataType, dataId, entry.Page, entry.Idx, ex)
 		}
-		_, err = s.Data.GetData(rec.Type, rec.Id)
+		_, err = s.Data.LocalData(rec.Type, rec.Id)
 		if err != nil {
 			if err.Status != http.StatusNotFound {
 				s.Log(fmt.Sprintf("processDataChange[%s/%s]: failed to get current record, Error:%s", rec.Type, rec.Id, err))

--- a/src/DataService/DataJournal/Process/schema.go
+++ b/src/DataService/DataJournal/Process/schema.go
@@ -165,7 +165,7 @@ func (s *SchemaChanges) subscribeCMT(schemaRec *Record.Record) *Http.HttpError {
 	return nil
 }
 
-func (s *SchemaChanges) subscribeIndex(dataType string, version string, idx CmtIndex.AutoIndex) *Http.HttpError {
+func (s *SchemaChanges) subscribeIndex(dataType string, version string, idx *CmtIndex.AutoIndex) *Http.HttpError {
 	cmtIdx := CmtIndex.CmtIndex{
 		DataType: idx.ContentType,
 		Subscriber: map[string]CmtIndex.CmtSubscriber{
@@ -189,7 +189,7 @@ func (s *SchemaChanges) subscribeIndex(dataType string, version string, idx CmtI
 	return nil
 }
 
-func (s *SchemaChanges) removeIdxSubscription(dataType string, version string, idx CmtIndex.AutoIndex) *Http.HttpError {
+func (s *SchemaChanges) removeIdxSubscription(dataType string, version string, idx *CmtIndex.AutoIndex) *Http.HttpError {
 	_, err := s.Data.Inventory.Get(CmtIndex.KeyCmtIdx, idx.ContentType)
 	if err != nil {
 		if err.Status != http.StatusNotFound {

--- a/src/DataService/DataServer/dataServer.go
+++ b/src/DataService/DataServer/dataServer.go
@@ -170,7 +170,12 @@ func (srv *Server) init() error {
 }
 
 func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
-	dataType, idPath := Util.ParsePath(r.URL.Path)
+	requestUrl, err := Http.GetUrl(r)
+	if err != nil {
+		srv.log.Printf("failed to parse request URL. Error:%s", err)
+		Http.ResponseJson(w, err, err.Status, srv.config.Http)
+	}
+	dataType, idPath := Util.ParsePath(requestUrl)
 	srv.log.Printf("process request[%s] on [%s/%s]", r.Method, dataType, idPath)
 	if dataType == Record.KeyRecord {
 		srv.log.Printf("Invalid request on [%s]", dataType)
@@ -213,8 +218,8 @@ func (srv *Server) handler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (srv *Server) handleGet(w http.ResponseWriter, dataType string, dataId string) {
-	if dataId == "" {
+func (srv *Server) handleGet(w http.ResponseWriter, dataType string, idPath string) {
+	if idPath == "" {
 		srv.log.Printf("list id of [%s]", dataType)
 		idList, err := srv.data.List(dataType)
 		if err != nil {
@@ -228,11 +233,11 @@ func (srv *Server) handleGet(w http.ResponseWriter, dataType string, dataId stri
 	var err *Http.HttpError
 	switch dataType {
 	case Common.KeyJournal:
-		srv.log.Printf("get Journal of type [%s]", dataId)
-		result, err = srv.journal.GetJournal(dataId)
+		srv.log.Printf("get Journal of type [%s]", idPath)
+		result, err = srv.journal.GetJournal(idPath)
 	default:
-		srv.log.Printf("get data of [%s/%s]", dataType, dataId)
-		result, err = srv.data.Get(dataType, dataId)
+		srv.log.Printf("get data of [%s/%s]", dataType, idPath)
+		result, err = srv.data.Get(dataType, idPath)
 	}
 	if err != nil {
 		Http.ResponseJson(w, err, err.Status, srv.config.Http)

--- a/src/InventoryService/DataHandler/dataHandler.go
+++ b/src/InventoryService/DataHandler/dataHandler.go
@@ -182,7 +182,10 @@ func (h *Handler) GetSchemaRecord(dataType string) (*Record.Record, *Http.HttpEr
 		}
 		return record, nil
 	}
-	schemaName, _ := SchemaDoc.ParseDataType(dataType)
+	schemaName, _, ex := SchemaDoc.ParseDataType(dataType)
+	if ex != nil {
+		return nil, Http.WrapError(ex, fmt.Sprintf("failed to parse schema type[%s]", dataType), http.StatusBadRequest)
+	}
 	referral, err := h.GetReferral(schemaName)
 	if err != nil {
 		return nil, err

--- a/test/src/DataServiceTest/JournalProcessesTest/multiLayerMultiPathAutoIndex_test.go
+++ b/test/src/DataServiceTest/JournalProcessesTest/multiLayerMultiPathAutoIndex_test.go
@@ -320,7 +320,7 @@ func TestForAddLayerToExistsIdxTree(t *testing.T) {
 		}
 	}`
 	addSchema(env, Layer1SchemaV1)
-	cmtIdxData, err := env.Handler.GetData(CmtIndex.KeyCmtIdx, "leaf")
+	cmtIdxData, err := env.Handler.LocalData(CmtIndex.KeyCmtIdx, "leaf")
 	if err != nil {
 		t.Fatalf("failed to get [%s] record for [leaf], Error:%s", CmtIndex.KeyCmtIdx, err)
 	}
@@ -458,7 +458,7 @@ func TestForAddLayerToExistsIdxTree(t *testing.T) {
 		}
 	}`
 	addSchema(env, layer2SchemaV1)
-	cmtIdxData, err = env.Handler.GetData(CmtIndex.KeyCmtIdx, "leaf")
+	cmtIdxData, err = env.Handler.LocalData(CmtIndex.KeyCmtIdx, "leaf")
 	if err != nil {
 		t.Fatalf("failed to get [%s] record for [leaf], Error:%s", CmtIndex.KeyCmtIdx, err)
 	}

--- a/test/src/DataServiceTest/JournalProcessesTest/oneLayerAutoIndex_test.go
+++ b/test/src/DataServiceTest/JournalProcessesTest/oneLayerAutoIndex_test.go
@@ -249,7 +249,7 @@ func addLayer1SchemaDataAndUpgradSchema(t *TestEnv) {
 		}
 	}`
 	addData(t, catLayer1Data1)
-	_, err := t.Handler.Get(CmtIndex.KeyCmtIdx, "test")
+	_, err := t.Handler.LocalData(CmtIndex.KeyCmtIdx, "test")
 	if err == nil {
 		t.T.Fatal("there should be no CmtIndex of Type=[test]")
 	}
@@ -277,7 +277,7 @@ func addLayer1SchemaDataAndUpgradSchema(t *TestEnv) {
 		}
 	}`
 	addSchema(t, catLayer1SchemaV2)
-	cmtIdxData, err := t.Handler.Get(CmtIndex.KeyCmtIdx, "test")
+	cmtIdxData, err := t.Handler.LocalData(CmtIndex.KeyCmtIdx, "test")
 	if err != nil {
 		t.T.Fatal("failed to add CmtIndex of Type=[test]")
 	}

--- a/test/src/DataServiceTest/dataHandlerSchema_test.go
+++ b/test/src/DataServiceTest/dataHandlerSchema_test.go
@@ -78,7 +78,7 @@ func TestAddSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to add init schema. Error: %s", err)
 	}
-	data, err := handler.Get(JsonKey.Schema, "test")
+	data, err := handler.LocalData(JsonKey.Schema, "test")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -107,7 +107,7 @@ func TestAddSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to add new schema. Error: %s", err)
 	}
-	data, err = handler.Get(JsonKey.Schema, "test")
+	data, err = handler.LocalData(JsonKey.Schema, "test")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/test/src/DataServiceTest/dataHandler_test.go
+++ b/test/src/DataServiceTest/dataHandler_test.go
@@ -289,7 +289,7 @@ func TestDataHandlerPatchAttr(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
-	data, e := handler.Get("test", "test01")
+	data, e := handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -297,7 +297,7 @@ func TestDataHandlerPatchAttr(t *testing.T) {
 		t.Fatalf("patch failed")
 	}
 	handler.Patch("test", "test01/attr2", nil, 2)
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -312,7 +312,7 @@ func TestDataHandlerPatchAttr(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch next level of attr. Err: %s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -326,7 +326,7 @@ func TestDataHandlerPatchAttr(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch next level of attr. Err: %s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -489,10 +489,11 @@ func TestDataHandlerPatchArrayObj(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e := handler.Get("test", "test01")
+	result, e := handler.Get("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
+	data := result.(map[string]interface{})
 	if len(data[Record.Data].(map[string]interface{})["attr1"].([]interface{})) != 1 {
 		t.Fatalf("patch failed")
 	}
@@ -504,7 +505,7 @@ func TestDataHandlerPatchArrayObj(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -518,7 +519,7 @@ func TestDataHandlerPatchArrayObj(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -534,7 +535,7 @@ func TestDataHandlerPatchArrayObj(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -548,7 +549,7 @@ func TestDataHandlerPatchArrayObj(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -710,7 +711,7 @@ func TestDataHandlerPatchArraySimpleStr(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e := handler.Get("test", "test01")
+	data, e := handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -724,7 +725,7 @@ func TestDataHandlerPatchArraySimpleStr(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -738,7 +739,7 @@ func TestDataHandlerPatchArraySimpleStr(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -752,7 +753,7 @@ func TestDataHandlerPatchArraySimpleStr(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -915,7 +916,7 @@ func TestDataHandlerPatchArrayInt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e := handler.Get("test", "test01")
+	data, e := handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -929,7 +930,7 @@ func TestDataHandlerPatchArrayInt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -943,7 +944,7 @@ func TestDataHandlerPatchArrayInt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -957,7 +958,7 @@ func TestDataHandlerPatchArrayInt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -974,7 +975,7 @@ func TestDataHandlerPatchArrayInt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -1140,7 +1141,7 @@ func TestDataHandlerPatchArrayCmt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e := handler.Get("test", "test01")
+	data, e := handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -1154,7 +1155,7 @@ func TestDataHandlerPatchArrayCmt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	data, e = handler.LocalData("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
@@ -1175,10 +1176,11 @@ func TestDataHandlerPatchArrayCmt(t *testing.T) {
 	if e != nil {
 		t.Fatalf("failed to patch data. Error:%s", e)
 	}
-	data, e = handler.Get("test", "test01")
+	result, e := handler.Get("test", "test01")
 	if e != nil {
 		t.Fatalf("failed to get patched data")
 	}
+	data = result.(map[string]interface{})
 	if len(data[Record.Data].(map[string]interface{})["attr4"].([]interface{})) != 2 {
 		t.Fatalf("patch failed")
 	}

--- a/test/src/SchemaPathTest/schemaPathIter_test.go
+++ b/test/src/SchemaPathTest/schemaPathIter_test.go
@@ -196,7 +196,7 @@ func TestIterOneFork(t *testing.T) {
 		"refObj": {
 			"ref01_01": {
 				"__id": "ref01_01",
-				"__type": "Obj",
+				"__type": "refObj",
 				"__ver": "0.0.1",
 				"data": {
 					"key1": "01",
@@ -206,7 +206,7 @@ func TestIterOneFork(t *testing.T) {
 			},
 			"ref01_02": {
 				"__id": "ref01_02",
-				"__type": "Obj",
+				"__type": "refObj",
 				"__ver": "0.0.1",
 				"data": {
 					"key1": "01",
@@ -600,7 +600,7 @@ func TestIterTwoForks(t *testing.T) {
 		"refObj": {
 			"ref01_01": {
 				"__id": "ref01_01",
-				"__type": "Obj",
+				"__type": "refObj",
 				"__ver": "0.0.1",
 				"data": {
 					"key1": "01",
@@ -610,7 +610,7 @@ func TestIterTwoForks(t *testing.T) {
 			},
 			"ref01_02": {
 				"__id": "ref01_02",
-				"__type": "Obj",
+				"__type": "refObj",
 				"__ver": "0.0.1",
 				"data": {
 					"key1": "01",
@@ -1037,7 +1037,7 @@ func TestIterFilter(t *testing.T) {
 		"refObj": {
 			"ref01_01": {
 				"__id": "ref01_01",
-				"__type": "Obj",
+				"__type": "refObj",
 				"__ver": "0.0.1",
 				"data": {
 					"key1": "01",
@@ -1047,7 +1047,7 @@ func TestIterFilter(t *testing.T) {
 			},
 			"ref01_02": {
 				"__id": "ref01_02",
-				"__type": "Obj",
+				"__type": "refObj",
 				"__ver": "0.0.1",
 				"data": {
 					"key1": "01",


### PR DESCRIPTION
 - Add capability of walk data from Data Service
 - - Data Service registry and referral record all still come from Inventory Service
 - - cannot walk schema
 - - the walk has to start from local data of the Data Service
 - - only list data type from local, still need to go to inventory service to see all data type
 - - fix test bugs